### PR TITLE
Fix `mailto` link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,4 +199,4 @@ Vinícius Vielmo Cogo provided an html output scheme.
 
 * * *
 
-<address>[Neil Spring](mailto:nspring@cs.umd.edu)</address>
+[Neil Spring](mailto:nspring@cs.umd.edu)


### PR DESCRIPTION
The current version `<address>` which is not recognized by GitHub
flavored Markdown. The link is broken because of that.